### PR TITLE
Update app.yaml

### DIFF
--- a/complete/src/main/appengine/app.yaml
+++ b/complete/src/main/appengine/app.yaml
@@ -6,7 +6,11 @@ runtime_config:
     server: jetty9
 
 health_check:
-    enable_health_check: False
+    enable_health_check: True
+    check_interval_sec: 8
+    timeout_sec: 4
+    unhealthy_threshold: 2
+    healthy_threshold: 2
 
 resources:
     cpu: 1


### PR DESCRIPTION
Settings enable_heald_check: False was failing, or else it was one of the other variables which were possibly default to 0, but appengine now doesn't like.  I used these values and it launches.

Keep or drop the change, but as setup does not successfully deploy.